### PR TITLE
Fix Claude Code Review workflow permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr view * --web),Bash(gh pr list:*)"'
 


### PR DESCRIPTION
## Summary
- Fixed the Claude Code Review workflow to allow `gh pr view --web` command

## Problem
The workflow was failing with:
```
Error: Bash tool call was blocked: Command does not match any allowed pattern: gh pr view 1 --web
```

## Solution
Added `Bash(gh pr view * --web)` to the allowed tools list in the workflow configuration.

## Test plan
- [x] Create this PR to trigger the workflow
- [ ] Verify the workflow runs successfully without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)